### PR TITLE
Use config module and clean CLI code

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,14 +15,16 @@ import threading
 import os
 import atexit
 from datetime import datetime, timedelta
+from config import get_config
 
-# Configuration constants
-MAX_WORKERS = 3
-CHUNK_SIZE = 500  # Process articles in chunks of 500
-REQUEST_TIMEOUT = 15
-GC_ENABLED = True
-DB_PATH = "temp_products.db"
-SESSION_CLEANUP_HOURS = 24  # Clean up sessions older than 24 hours
+# Load configuration
+cfg = get_config()
+MAX_WORKERS = cfg.MAX_WORKERS
+CHUNK_SIZE = cfg.CHUNK_SIZE
+REQUEST_TIMEOUT = cfg.REQUEST_TIMEOUT
+GC_ENABLED = cfg.GC_ENABLED
+DB_PATH = cfg.DB_PATH
+SESSION_CLEANUP_HOURS = cfg.SESSION_CLEANUP_HOURS
 
 app = Flask(__name__, static_folder="static", template_folder="templates")
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/config.py
+++ b/config.py
@@ -213,23 +213,3 @@ def print_config_summary(config):
               f"{estimate['chunks_needed']:>3} chunks")
     print("="*50 + "\n")
 
-if __name__ == "__main__":
-    # Example usage and testing
-    config = get_config()
-    print_config_summary(config)
-    
-    # Validate configuration
-    errors = validate_config(config)
-    if errors:
-        print("Configuration Errors:")
-        for error in errors:
-            print(f"  - {error}")
-    else:
-        print("✓ Configuration is valid")
-    
-    # Show available profiles
-    print("\nAVAILABLE PERFORMANCE PROFILES:")
-    print("-" * 50)
-    for name, profile in PERFORMANCE_PROFILES.items():
-        print(f"{name:>15}: {profile['description']}")
-    print("-" * 50)


### PR DESCRIPTION
## Summary
- load configuration constants from `config.get_config()` in `app.py`
- strip CLI/testing code from `config.py`

## Testing
- `python -m py_compile app.py config.py`
- `flake8 app.py config.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b4da1a848329a3997fdddd25d537